### PR TITLE
feat(api): Add endpoint to list all user images without pagination

### DIFF
--- a/backend/src/collections/image-db/image-db.service.ts
+++ b/backend/src/collections/image-db/image-db.service.ts
@@ -83,6 +83,28 @@ export class ImageDBService {
     }
   }
 
+  public async findAll(
+    userid: string | undefined,
+  ): AsyncFailable<{ results: EImageBackend[]; total: number }> {
+    try {
+      const [found, amount] = await this.imageRepo.findAndCount({
+        order: { created: 'DESC' },
+        where: {
+          user_id: userid,
+        },
+      });
+
+      if (found === undefined) return Fail(FT.NotFound, 'Images not found');
+
+      return {
+        results: found,
+        total: amount,
+      };
+    } catch (e) {
+      return Fail(FT.Database, e);
+    }
+  }
+
   public async count(): AsyncFailable<number> {
     try {
       return await this.imageRepo.count();

--- a/backend/src/managers/image/image.service.ts
+++ b/backend/src/managers/image/image.service.ts
@@ -57,6 +57,12 @@ export class ImageManagerService {
     return await this.imagesService.findMany(count, page, userid);
   }
 
+  public async findAll(
+    userid: string | undefined,
+  ): AsyncFailable<{ results: EImageBackend[]; total: number }> {
+    return await this.imagesService.findAll(userid);
+  }
+
   public async update(
     id: string,
     userid: string | undefined,

--- a/backend/src/routes/image/image-manage.controller.ts
+++ b/backend/src/routes/image/image-manage.controller.ts
@@ -13,6 +13,8 @@ import {
     ImageDeleteResponse,
     ImageDeleteWithKeyRequest,
     ImageDeleteWithKeyResponse,
+    ImageListAllRequest,
+    ImageListAllResponse,
     ImageListRequest,
     ImageListResponse,
     ImageUpdateRequest,
@@ -88,6 +90,25 @@ export class ImageManageController {
 
     const found = ThrowIfFailed(
       await this.imagesService.findMany(body.count, body.page, body.user_id),
+    );
+
+    return found;
+  }
+
+  @Post('list/all')
+  @RequiredPermissions(Permission.ImageManage)
+  @Returns(ImageListAllResponse)
+  async listAllMyImages(
+    @Body() body: ImageListAllRequest,
+    @ReqUserID() userid: string,
+    @HasPermission(Permission.ImageAdmin) isImageAdmin: boolean,
+  ): Promise<ImageListAllResponse> {
+    if (!isImageAdmin) {
+      body.user_id = userid;
+    }
+
+    const found = ThrowIfFailed(
+      await this.imagesService.findAll(body.user_id),
     );
 
     return found;

--- a/frontend/src/app/services/api/image.service.ts
+++ b/frontend/src/app/services/api/image.service.ts
@@ -1,7 +1,12 @@
 import { Injectable } from '@angular/core';
+import { Logger } from '../../logger';
 import {
   ImageDeleteRequest,
   ImageDeleteResponse,
+  ImageDeleteWithKeyRequest,
+  ImageDeleteWithKeyResponse,
+  ImageListAllRequest,
+  ImageListAllResponse,
   ImageListRequest,
   ImageListResponse,
   ImageUpdateRequest,
@@ -27,6 +32,7 @@ import { ImageUploadRequest } from '../../models/dto/image-upload-request.dto';
 import { ApiService } from './api.service';
 import { InfoService } from './info.service';
 import { UserService } from './user.service';
+import { AutoUnsubscribe } from '../../decorators/autounsub.decorator';
 
 @Injectable({
   providedIn: 'root',
@@ -84,6 +90,19 @@ export class ImageService {
     ).result;
   }
 
+  public async ListAllImagesUnpaged(
+    userID?: string,
+  ): AsyncFailable<ImageListAllResponse> {
+    return await this.api.post(
+      ImageListAllRequest,
+      ImageListAllResponse,
+      '/api/image/list/all',
+      {
+        user_id: userID,
+      },
+    ).result;
+  }
+
   public async ListMyImages(
     count: number,
     page: number,
@@ -94,6 +113,15 @@ export class ImageService {
     }
 
     return await this.ListAllImages(count, page, userID);
+  }
+
+  public async ListAllMyImagesUnpaged(): AsyncFailable<ImageListAllResponse> {
+    const userID = await this.userService.snapshot?.id;
+    if (userID === undefined) {
+      return Fail(FT.Authentication, 'User not logged in');
+    }
+
+    return await this.ListAllImagesUnpaged(userID);
   }
 
   public async UpdateImage(

--- a/shared/src/dto/api/image-manage.dto.ts
+++ b/shared/src/dto/api/image-manage.dto.ts
@@ -77,3 +77,15 @@ export const ImageDeleteWithKeyResponseSchema = EImageSchema;
 export class ImageDeleteWithKeyResponse extends createZodDto(
   ImageDeleteWithKeyResponseSchema,
 ) {}
+
+// Image List All
+export const ImageListAllRequestSchema = z.object({
+  user_id: z.string().uuid().optional(),
+});
+export class ImageListAllRequest extends createZodDto(ImageListAllRequestSchema) {}
+
+export const ImageListAllResponseSchema = z.object({
+  results: z.array(EImageSchema),
+  total: IsPosInt(),
+});
+export class ImageListAllResponse extends createZodDto(ImageListAllResponseSchema) {}


### PR DESCRIPTION
This commit adds a new API endpoint that allows retrieving all images uploaded 
by a user in a single request, without pagination limits. The existing endpoint 
is limited to 100 images per page.

Changes:
- Added new DTOs: ImageListAllRequest and ImageListAllResponse
- Added findAll method to ImageDBService to fetch all images for a user
- Added corresponding method to ImageManagerService
- Added new endpoint POST /api/image/list/all to ImageManageController
- Added frontend service methods to consume the new API

The new endpoint requires the same permissions as the existing paginated endpoint
(ImageManage) and follows the same authentication pattern.